### PR TITLE
Switch to distroless image and don't run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ COPY *.go go.mod go.sum /src/
 RUN apk add git
 RUN go build .
 
-FROM alpine
+FROM gcr.io/distroless/static-debian11:nonroot
 COPY --from=build /src/exporter_exporter /usr/bin/
 COPY k8s.yml /expexp.yaml
+USER nonroot
 ENTRYPOINT ["/usr/bin/exporter_exporter"]


### PR DESCRIPTION
- distroless is smaller images and more secure than alpine, it's a perfect fit for static go apps
- with nonroot tag of distroless images we get a nonroot user ready to be used with the container, so use this user so we don't run as root when not needed